### PR TITLE
ci: GitHub Actionsへsafe-chainを適用

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -30,8 +30,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: build
-        run: npm ci && npm run build
+      - name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## 概要
GitHub Actions のワークフローに AikidoSec/safe-chain を導入しました。

## 変更内容
- `.github/workflows/gh_pages.yml` に safe-chain インストール手順を追加
  - `curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci`
- `npm ci && npm run build` の複合コマンドを以下に分割
  - `Install dependencies` (`npm ci`)
  - `Build` (`npm run build`)

## スコープ
- ワークフロー/CI 変更のみ（依存関係・ライブラリバージョンの更新なし）

## 確認観点
- safe-chain が `npm ci` より前に実行されること
- 既存のビルド/Pagesデプロイ処理に影響がないこと
