### PR TITLE
chore: .npmrc に min-release-age=2880 を追加

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=2880


### PR DESCRIPTION
## 概要
- `.npmrc` に `min-release-age=2880`（2日）を追加しました。

## 変更内容
- `min-release-age=2880` を設定

## 補足
- 設定追加のみのため、テスト実行は省略しています。
