### PR TITLE
TypeScript を 6 系に更新

### DIFF
--- a/.pr_body_typescript6_20260422.md
+++ b/.pr_body_typescript6_20260422.md
@@ -1,0 +1,17 @@
+## 概要
+- `typescript` を 5.9.3 から 6.0.3 へ更新しました
+- TypeScript 6 の breaking changes を確認し、このリポジトリで必要だった対応を加えました
+
+## 変更内容
+- `typescript` 5.9.3 -> 6.0.3
+- `tsconfig.json` の `moduleResolution` を `node` から `bundler` に変更
+- TypeScript 6 で CSS の side-effect import がエラーになったため、`index.d.ts` に `declare module '*.css';` を追加
+
+## breaking changes の確認メモ
+- TypeScript 6 の案内で `moduleResolution: node` 相当の `node10` が非推奨になり、7.0 で無効化予定とされていました
+- 実際に `npm run build` で `TS5107` が発生したため、Vite アプリに適した `bundler` へ移行しました
+- その後、CSS の side-effect import に対する型宣言不足が `TS2882` として表面化したため、宣言ファイルを追加して解消しました
+
+## 確認結果
+- `npm test`: テストファイルが存在しないため Vitest は exit code 1 でしたが、リポジトリルールに従いテストなしとして扱っています
+- `npm run build`: 成功

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
                 "react-router-dom": "^6.30.3",
-                "typescript": "^5.9.3"
+                "typescript": "^6.0.3"
             },
             "devDependencies": {
                 "@tailwindcss/forms": "^0.5.11",
@@ -5890,9 +5890,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -10120,9 +10120,9 @@
             }
         },
         "typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="
         },
         "ufo": {
             "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.30.3",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
     },
     "scripts": {
         "start": "vite",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
         "forceConsistentCasingInFileNames": true,
         "noFallthroughCasesInSwitch": true,
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
         "resolveJsonModule": true,
         "isolatedModules": true,
         "noEmit": true,


### PR DESCRIPTION
## 概要
- `typescript` を 5.9.3 から 6.0.3 へ更新しました
- TypeScript 6 の breaking changes を確認し、このリポジトリで必要だった対応を加えました

## 変更内容
- `typescript` 5.9.3 -> 6.0.3
- `tsconfig.json` の `moduleResolution` を `node` から `bundler` に変更
- TypeScript 6 で CSS の side-effect import がエラーになったため、`index.d.ts` に `declare module '*.css';` を追加

## breaking changes の確認メモ
- TypeScript 6 の案内で `moduleResolution: node` 相当の `node10` が非推奨になり、7.0 で無効化予定とされていました
- 実際に `npm run build` で `TS5107` が発生したため、Vite アプリに適した `bundler` へ移行しました
- その後、CSS の side-effect import に対する型宣言不足が `TS2882` として表面化したため、宣言ファイルを追加して解消しました

## 確認結果
- `npm test`: テストファイルが存在しないため Vitest は exit code 1 でしたが、リポジトリルールに従いテストなしとして扱っています
- `npm run build`: 成功
