### PR TITLE
chore: @types/node を v25 系へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "@octokit/core": "^7.0.6",
                 "@tanstack/react-query": "^5.99.2",
-                "@types/node": "^20.19.39",
+                "@types/node": "^25.6.0",
                 "@types/react": "^18.3.28",
                 "@types/react-dom": "^18.3.7",
                 "isomorphic-fetch": "^3.0.0",
@@ -1160,12 +1160,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.19.39",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-            "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+            "version": "25.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.21.0"
+                "undici-types": "~7.19.0"
             }
         },
         "node_modules/@types/prop-types": {
@@ -5929,9 +5929,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "version": "7.19.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
             "license": "MIT"
         },
         "node_modules/universal-user-agent": {
@@ -7014,11 +7014,11 @@
             "dev": true
         },
         "@types/node": {
-            "version": "20.19.39",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-            "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+            "version": "25.6.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+            "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
             "requires": {
-                "undici-types": "~6.21.0"
+                "undici-types": "~7.19.0"
             }
         },
         "@types/prop-types": {
@@ -10143,9 +10143,9 @@
             }
         },
         "undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+            "version": "7.19.2",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+            "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
         },
         "universal-user-agent": {
             "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@octokit/core": "^7.0.6",
         "@tanstack/react-query": "^5.99.2",
-        "@types/node": "^20.19.39",
+        "@types/node": "^25.6.0",
         "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.7",
         "isomorphic-fetch": "^3.0.0",


### PR DESCRIPTION
## 概要
- `@types/node` を `20.19.39` から `25.6.0` へメジャー更新しました。
- semver範囲外（major）更新のため、このPRは **1依存関係のみ** を扱っています。

## 変更内容
- `package.json` の `@types/node` を `^25.6.0` へ更新
- `package-lock.json` を更新

## 変更ログ / Breaking Changes の確認
- Node.js v25.0.0 のリリースノートを確認し、複数の SemVer Major 変更（非推奨APIの削除・EOL移行など）があることを確認しました。
- 本リポジトリはブラウザ向けの React/Vite アプリで、Node 実行時 API への直接依存は薄く、影響は主に型定義とビルド周辺に限定される想定です。

## 検証
- テストファイルなし（repo CI と同じ条件で `npm test` はスキップ扱い）
- `npm run build` ✅

CI 成功を確認後にマージします。
