### PR TITLE
chore: Pages workflow の Node.js を 24 に更新

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 16
+          node-version: 24
       - name: Install safe-chain
         run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
       - name: Install dependencies


### PR DESCRIPTION
## 概要
- GitHub Pages workflow の Node.js を `16` から `24` に更新
- Vite の build 要件を満たす Node 系へ引き上げ

## 背景
- Pages workflow が `node-version: 16` のままで、main へ merge すると deploy failure を積み増す状態だった
- 既知の失敗理由は `Vite requires Node.js 20.19+ or 22.12+`

## 変更内容
- `.github/workflows/gh_pages.yml`
  - `actions/setup-node` の `node-version` を `24` に変更

## 確認
- workflow 差分を確認
- root build が Node 16 起因で詰まっていたことを既存ログで確認済み