### PR TITLE
Group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,40 @@
 version: 2
+
+multi-ecosystem-groups:
+  dependency-updates:
+    schedule:
+      interval: "weekly"
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependency-updates"
     cooldown:
       default-days: 2
+    groups:
+      all-npm-security-updates:
+        applies-to: "security-updates"
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependency-updates"
+    cooldown:
+      default-days: 2
+    groups:
+      all-backend-npm-security-updates:
+        applies-to: "security-updates"
+        patterns: ["*"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependency-updates"
+    cooldown:
+      default-days: 2
+    groups:
+      all-github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns: ["*"]


### PR DESCRIPTION
### Motivation
- Dependabot が作成する複数の依存関係更新 PR を可能な限りまとめてノイズを減らすため、週次のマルチエコシステムグループを導入しました。 
- ルート npm、`/backend` npm、および GitHub Actions の更新を同一グループに割り当てて一括で扱えるようにします。

### Description
- `.github/dependabot.yml` に `multi-ecosystem-groups` の `dependency-updates` を追加しスケジュールを週次に設定しました.
- ルート (`/`) の `npm`、`/backend` の `npm`、および `github-actions` 用の `updates` エントリを追加し、`patterns: ["*"]` と `multi-ecosystem-group: "dependency-updates"` を設定しました.
- 各エコシステムに対して `applies-to: "security-updates"` のワイルドカードグループを追加し、既存の `cooldown.default-days: 2` 相当の設定を維持しました.
- 既存の個別週次スケジュール行はグループ設定に置き換えられています.

### Testing
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort("bad version") unless data["version"] == 2; abort("missing multi-ecosystem-groups") unless data.dig("multi-ecosystem-groups", "dependency-updates", "schedule", "interval") == "weekly"; updates = data["updates"]; abort("bad updates") unless updates.is_a?(Array) && updates.size == 3; abort("missing wildcard patterns") unless updates.all? { |u| u["patterns"] == ["*"] && u["multi-ecosystem-group"] == "dependency-updates" }; abort("missing security groups") unless updates.all? { |u| u["groups"].is_a?(Hash) && u["groups"].values.any? { |g| g["applies-to"] == "security-updates" && g["patterns"] == ["*"] } }; puts "dependabot.yml is valid YAML"'` was run and succeeded.
- `git diff --check` was run and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b85db33c83269a6facae392c6e3a)