### PR TITLE
Dependabot設定を更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,40 +1,55 @@
 version: 2
-
-multi-ecosystem-groups:
-  dependency-updates:
-    schedule:
-      interval: "weekly"
-
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    patterns: ["*"]
-    multi-ecosystem-group: "dependency-updates"
+    schedule:
+      interval: "weekly"
     cooldown:
-      default-days: 2
+      default-days: 7
+      semver-major-days: 60
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-npm-security-updates:
         applies-to: "security-updates"
-        patterns: ["*"]
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/backend"
-    patterns: ["*"]
-    multi-ecosystem-group: "dependency-updates"
+    schedule:
+      interval: "weekly"
     cooldown:
-      default-days: 2
+      default-days: 7
+      semver-major-days: 60
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-backend-npm-security-updates:
         applies-to: "security-updates"
-        patterns: ["*"]
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    patterns: ["*"]
-    multi-ecosystem-group: "dependency-updates"
+    schedule:
+      interval: "weekly"
     cooldown:
-      default-days: 2
+      default-days: 7
+      semver-major-days: 60
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-github-actions-security-updates:
         applies-to: "security-updates"
-        patterns: ["*"]
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-      semver-major-days: 60
     ignore:
       - dependency-name: "*"
         update-types:


### PR DESCRIPTION
### Motivation
- 参考リポジトリに合わせてDependabotの実行頻度とノイズを調整し、セキュリティ更新は検出・まとめて扱えるようにする。

### Description
- `.github/dependabot.yml`を更新してルート、`/backend`のnpm、及び`github-actions`を週次スキャンするようにした。
- マイナー/パッチの通常更新を無視する設定と、`cooldown`および`semver-major-days`でメジャー更新の遅延を設定した。 
- セキュリティ更新はグループ化してまとめる設定（`applies-to: "security-updates"`）を追加した。
- `ignore`/`groups`キーを追加して依存関係パターンと更新ポリシーを明確化した。

### Testing
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`でYAMLの読み込み検証を実行し成功した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b21e0bb4483269cf42a38641da959)